### PR TITLE
Fix recommended travel tours

### DIFF
--- a/modules/tour/travels/server/procedures.ts
+++ b/modules/tour/travels/server/procedures.ts
@@ -38,8 +38,8 @@ export const tourTravelRouter = createTRPCRouter({
 
   listReccommended: baseProcedure.query(async ({ ctx }) => {
     const payloadData = await ctx.db.find({
-      collection: "tour-studies",
-      where: { isFeatured: { equals: true } },
+      collection: "tour-travel",
+      where: { isPublished: { equals: true } },
       limit: 3,
       pagination: false,
       depth: 1,


### PR DESCRIPTION
## Summary
- fix recommended tours query for TourTravel router to use the correct collection and filter by `isPublished`

## Testing
- `pnpm install`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_686209f178e4832ca029fb1000635366